### PR TITLE
Add support for using this plugin from other repositories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1574,6 +1574,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "jwks-router-plugin"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "apollo-router",
+ "async-trait",
+ "futures",
+ "jsonwebtoken",
+ "reqwest",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2676,24 +2694,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "which",
-]
-
-[[package]]
-name = "router-extension-template"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "apollo-router",
- "async-trait",
- "futures",
- "jsonwebtoken",
- "reqwest",
- "schemars",
- "serde",
- "serde_json",
- "tokio",
- "tower",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [package]
-name = "router-extension-template"
+name = "jwks-router-plugin"
 version = "0.1.0"
 edition = "2021"
 license = "Elastic-2.0"
@@ -8,6 +8,9 @@ license = "Elastic-2.0"
 [[bin]]
 name = "router"
 path = "src/main.rs"
+
+[lib]
+path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1.0.55"

--- a/README.md
+++ b/README.md
@@ -24,9 +24,40 @@ plugins:
     token_prefix: Bearer
 ```
 
-By default, the plugin looks for an `Authorization` header and the token prefixed by `Bearer`. The plugin supports an optional empty prefix if you prefer to pass without it.
+## Usage from Your Router Repository
 
-Additionally, the plugin will pass the defined header to the subgraph for validation at each level; this is by design, as it enables [a zero trust security model](https://en.wikipedia.org/wiki/Zero_trust_security_model).
+To this plugin from your own router repository, you'll need to include this
+`jwks-router-plugin` as a dependency in your `Cargo.toml` file. Since this plugin
+is not published to [crates.io](https://crates.io/), you can accomplish this using
+a GitHub reference. For example:
+
+```toml
+[dependencies]
+jwks-router-plugin = { git = "https://github.com/apollosolutions/jwks-router-plugin", branch="main" }
+```
+
+Then you'll need to register this plugin, which, can be done simply by adding it to your
+`plugins/mod.rs` file. Suppose your company, Acme, wanted to use this plugin as `achme.jwks`,
+rather than `example.jwks`, you'd simply add:
+
+```rust
+use apollo_router::register_plugin;
+pub use jwks_router_plugin::plugins::jwks_plugin::JwksPlugin;
+
+register_plugin!("acme", "jwks", JwksPlugin);
+```
+
+The prefix used when calling `register_plugin` is used below when configuring the plugin.
+Now you can configure your `router.yaml` file with your JWKS settings. 
+The configuration looks like:
+
+```yml
+plugins:
+  acme.jwks:
+    jwks_url: "JWKS_URL_HERE"
+    token_header: "Authorization"
+    token_prefix: Bearer
+```
 
 ## Test the plugin with Apollo Router
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ plugins:
 
 ## Usage from Your Router Repository
 
-To this plugin from your own router repository, you'll need to include this
+To use this plugin from your own router repository, you'll need to include
 `jwks-router-plugin` as a dependency in your `Cargo.toml` file. Since this plugin
 is not published to [crates.io](https://crates.io/), you can accomplish this using
 a GitHub reference. For example:
@@ -36,9 +36,9 @@ a GitHub reference. For example:
 jwks-router-plugin = { git = "https://github.com/apollosolutions/jwks-router-plugin", branch="main" }
 ```
 
-Then you'll need to register this plugin, which, can be done simply by adding it to your
-`plugins/mod.rs` file. Suppose your company, Acme, wanted to use this plugin as `achme.jwks`,
-rather than `example.jwks`, you'd simply add:
+Then you'll need to register this plugin in your own repository. This can be done by
+adding it to your `plugins/mod.rs` file. Suppose your company, Acme, wanted to register
+this plugin as `achme.jwks`, rather than `example.jwks`, you'd simply add:
 
 ```rust
 use apollo_router::register_plugin;
@@ -47,8 +47,8 @@ pub use jwks_router_plugin::plugins::jwks_plugin::JwksPlugin;
 register_plugin!("acme", "jwks", JwksPlugin);
 ```
 
-The prefix used when calling `register_plugin` is used below when configuring the plugin.
-Now you can configure your `router.yaml` file with your JWKS settings. 
+The prefix used when calling `register_plugin` is used when configuring the 
+plugin. Now you can configure your `router.yaml` file with your JWKS settings.
 The configuration looks like:
 
 ```yml
@@ -56,7 +56,7 @@ plugins:
   acme.jwks:
     jwks_url: "JWKS_URL_HERE"
     token_header: "Authorization"
-    token_prefix: Bearer
+    token_prefix: "Bearer"
 ```
 
 ## Test the plugin with Apollo Router

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod plugins;

--- a/src/plugins/jwks_plugin.rs
+++ b/src/plugins/jwks_plugin.rs
@@ -38,7 +38,7 @@ pub struct JwksPlugin {
 //     jwks: stores the jwks keyset within an Arc (for cross channel communication) and RwLock (to avoid race conditions) as a string, which is parsed
 //     by serde_json as needed
 //     url: URL to fetch the JWKS from (expecting the .well-known/jwks.json path)
-pub struct JwksManager {
+struct JwksManager {
     jwks: Arc<RwLock<String>>,
     url: String,
     // `Option` because in theory one can call `JwksManager::new()` but

--- a/src/plugins/jwks_plugin.rs
+++ b/src/plugins/jwks_plugin.rs
@@ -24,7 +24,7 @@ use tower::{util::BoxService, BoxError, ServiceBuilder, ServiceExt};
 
 // We are storing the configuration, but not using it. Hence the allow dead code.
 #[allow(dead_code)]
-struct JwksPlugin {
+pub struct JwksPlugin {
     configuration: Conf,
     // Which header to use; defaults to "Authorization"
     token_header: String,
@@ -38,7 +38,7 @@ struct JwksPlugin {
 //     jwks: stores the jwks keyset within an Arc (for cross channel communication) and RwLock (to avoid race conditions) as a string, which is parsed
 //     by serde_json as needed
 //     url: URL to fetch the JWKS from (expecting the .well-known/jwks.json path)
-struct JwksManager {
+pub struct JwksManager {
     jwks: Arc<RwLock<String>>,
     url: String,
     // `Option` because in theory one can call `JwksManager::new()` but
@@ -143,7 +143,7 @@ impl Drop for JwksManager {
 
 // Configuration options for the actual plugin
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-struct Conf {
+pub struct Conf {
     jwks_url: String,
     token_header: Option<String>,
     token_prefix: Option<String>,

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,2 +1,2 @@
-mod jwks_plugin;
+pub mod jwks_plugin;
 


### PR DESCRIPTION
This change makes the `jwks-router-plugin` available as a reusable library and documents how to use it in your own router project. The pull request provides the minimally viable amount of changes to make this possible.